### PR TITLE
Make header and pkgconfig installation optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,37 +249,45 @@ if(NOT DEFINED FORMAT_SERVICE_DOMAIN)
 endif()
 
 # Setup pkgconfig
-set(__pkg_config_private_libs ${_pkg_config_private_libs})
-set(_pkg_config_private_libs)
-foreach(L ${__pkg_config_private_libs})
-  if(L MATCHES "(.*)/?lib(.*)\\.")
-    if(CMAKE_MATCH_1)
-      list(APPEND _pkg_config_private_libs "-L${CMAKE_MATCH_1}")
+option(FFS_INSTALL_PKGCONFIG "Install FFS pkgconfig files" ON)
+mark_as_advanced(FFS_INSTALL_PKGCONFIG)
+if(FFS_INSTALL_PKGCONFIG)
+  set(__pkg_config_private_libs ${_pkg_config_private_libs})
+  set(_pkg_config_private_libs)
+  foreach(L ${__pkg_config_private_libs})
+    if(L MATCHES "(.*)/?lib(.*)\\.")
+      if(CMAKE_MATCH_1)
+        list(APPEND _pkg_config_private_libs "-L${CMAKE_MATCH_1}")
+      endif()
+      list(APPEND _pkg_config_private_libs "-l${CMAKE_MATCH_2}")
+    elseif(L MATCHES "^-")
+      list(APPEND _pkg_config_private_libs "${L}")
+    else()
+      list(APPEND _pkg_config_private_libs "-l${L}")
     endif()
-    list(APPEND _pkg_config_private_libs "-l${CMAKE_MATCH_2}")
-  elseif(L MATCHES "^-")
-    list(APPEND _pkg_config_private_libs "${L}")
-  else()
-    list(APPEND _pkg_config_private_libs "-l${L}")
-  endif()
-endforeach()
-string(REPLACE ";" " " _pkg_config_private_libs "${_pkg_config_private_libs}")
-string(REPLACE ";" " " _pkg_config_private_reqs "${_pkg_config_private_reqs}")
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/ffs.pc.in
-  ${CMAKE_CURRENT_BINARY_DIR}/ffs.pc
-  @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ffs.pc
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/ffs-config.in
-  ${CMAKE_CURRENT_BINARY_DIR}/ffs-config
-  @ONLY)
-install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/ffs-config
-  DESTINATION "${CMAKE_INSTALL_BINDIR}")
+  endforeach()
+  string(REPLACE ";" " " _pkg_config_private_libs "${_pkg_config_private_libs}")
+  string(REPLACE ";" " " _pkg_config_private_reqs "${_pkg_config_private_reqs}")
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/ffs.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/ffs.pc
+    @ONLY)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ffs.pc
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/ffs-config.in
+    ${CMAKE_CURRENT_BINARY_DIR}/ffs-config
+    @ONLY)
+  install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/ffs-config
+    DESTINATION "${CMAKE_INSTALL_BINDIR}")
+endif()
 
-install(FILES fm/fm.h cod/cod.h ${CMAKE_CURRENT_BINARY_DIR}/ffs/ffs.h
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+option(FFS_INSTALL_HEADERS "Install FFS header files" ON)
+mark_as_advanced(FFS_INSTALL_HEADERS)
+if(FFS_INSTALL_HEADERS)
+  install(FILES fm/fm.h cod/cod.h ${CMAKE_CURRENT_BINARY_DIR}/ffs/ffs.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()
 
 install(TARGETS ffs EXPORT ffs-targets
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT bin


### PR DESCRIPTION
This allows superbuild projects that include an internal copy of
FFS to omit the unwanted headers and pkgconfig files in their
installation.