### PR TITLE
ci: Add stubs for GitHub Actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,10 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+


### PR DESCRIPTION
This is an empty stub that needs to be in place on master to start getting the PR actions running