### PR TITLE
namespace try-run to avoid leaking to other projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,7 +318,7 @@ if(NOT HAS_IOV_BASE_IOVEC)
   set(NEED_IOVEC_DEFINE TRUE)
 endif()
 
-TRY_RUN(RUN_RESULT COMPILE_RESULT
+try_run(FFS_FLOAT_FORMAT_TEST COMPILE_RESULT
         # Binary directory:
         ${CMAKE_CURRENT_BINARY_DIR}/
         # source file


### PR DESCRIPTION
We reported in the ADIOS2 conda forge package the following error:
https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1394663&view=logs&j=db69ff9c-c538-59a2-7c84-8d855d452c43&t=6fce01b3-6b55-5d54-8ceb-301058dda3ba

While fixing the error is trivial it is confusing that we had to
override the RUN_RESULT variable and that it corresponeded to FFS.
