### PR TITLE
Add restart_format_server.sh wrapper script

### DIFF
--- a/fm/progs/restart_format_server.sh
+++ b/fm/progs/restart_format_server.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Wrapper script to properly restart format_server
+# Works around PID reuse bug in format_server's built-in detection
+
+if ! pgrep -x format_server > /dev/null; then
+    rm -f /tmp/format_server_pid
+    /home/ge10/bin/format_server -quiet
+fi


### PR DESCRIPTION
Workaround for PID reuse bug in format_server startup detection.

The check_for_running_server_and_fork() function uses kill(pid, 0) to verify if the old format_server process is still running, but this only checks if *any* process has that PID. After a server crash, if the stale PID in /tmp/format_server_pid gets reused by an unrelated process, the server refuses to restart with "not responding, but still running".

This wrapper script uses pgrep -x to verify an actual format_server process is running before invoking format_server, bypassing the buggy detection. Intended for use in cron jobs instead of calling format_server directly.