### PR TITLE
Add weekly scheduled CI build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,12 +1,14 @@
 name: Build and Test
 
-on: 
-  push: 
-    branches: 
-    - master 
-  pull_request: 
-    branches: 
-    - master 
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+  schedule:
+    - cron: '0 7 * * 1'  # Monday 7am UTC - weekly build to catch dependency issues 
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Summary
- Add scheduled CI trigger to run every Monday at 7am UTC
- Helps catch dependency issues early, similar to the dill project

## Test plan
- Verify the workflow syntax is valid
- Wait for next Monday to confirm scheduled run executes

🤖 Generated with [Claude Code](https://claude.com/claude-code)