### PR TITLE
Add ffs_free() function for Windows DLL heap compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.14)
 # The directory label is used for CDash to treat FFS as a subproject of GTKorvo
 set(CMAKE_DIRECTORY_LABELS FFS)
 
-project(FFS VERSION 3.1.10)
+project(FFS VERSION 3.2.0)
 
 # Some boilerplate to setup nice output directories
 include(GNUInstallDirs)

--- a/fm/fm.h
+++ b/fm/fm.h
@@ -13,6 +13,7 @@ extern FMContext create_FMcontext();
 extern FMContext create_local_FMcontext();
 extern void set_ignore_default_values_FMcontext(FMContext c);
 extern void free_FMcontext(FMContext c);
+extern void ffs_free(void *ptr);
 extern void add_ref_FMcontext(FMContext c);
 extern void FMcontext_allow_self_formats(FMContext fmc);
 extern int

--- a/fm/fm_formats.c
+++ b/fm/fm_formats.c
@@ -2929,6 +2929,12 @@ free_FMcontext(FMContext c)
     free(c);
 }
 
+extern void
+ffs_free(void *ptr)
+{
+    free(ptr);
+}
+
 #define DUMP
 #ifdef DUMP
 static void


### PR DESCRIPTION
## Summary
- Add `ffs_free()` function to properly free memory allocated by FFS on Windows
- Bump version to 3.2.0

## Background
On Windows, each DLL has its own CRT heap. Memory allocated inside one DLL must be freed by the same DLL. Functions like `global_name_of_FMFormat()` and `FMbase_type()` allocate memory that callers need to free, but if the caller is in a different DLL (like EVPath), calling `free()` directly causes heap corruption.

This is the same pattern as the `atl_free()` function added in GTKorvo/atl#41.

## Test plan
- Build on Windows and verify that cross-DLL memory freeing works correctly
- Existing tests should continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)