### PR TITLE
Fix race condition in parallel build by removing redundant docs target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,8 +190,6 @@ else()
                    COMMENT "Copying pregen structs.h to build area")
 endif()
 
-add_custom_target(docs ALL DEPENDS "cod_node.c")
-
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
    SET_SOURCE_FILES_PROPERTIES(cod.tab.c PROPERTIES COMPILE_FLAGS -Wno-unused-function)
 endif()


### PR DESCRIPTION
The 'docs' target was marked ALL and depended on cod_node.c, which in turn
depended on lex.yy.c. The 'ffs' library also depended on the 'generated'
target which depended on lex.yy.c. This caused both targets to trigger the
same copy command for lex.yy.c simultaneously during parallel builds,
resulting in a race condition.

The 'docs' target was redundant since the 'generated' target already handles
all necessary dependencies for the ffs library build.
