### PR TITLE
Fix type_alignment signed/unsigned bug and adios2_bug wrong sizeof

### DIFF
--- a/ffs/tests/adios2_bug.c
+++ b/ffs/tests/adios2_bug.c
@@ -395,7 +395,7 @@ static FMField ReturnMetadataInfoList[] = {
 
 static FMStructDescRec ReturnMetadataInfoStructs[] = {
     {"ReturnMetadataInfo", ReturnMetadataInfoList,
-     sizeof(struct _TimestepMetadataDistributionMsg), NULL},
+     sizeof(struct _ReturnMetadataInfo), NULL},
     {"ReleaseRec", ReleaseRecList, sizeof(struct _ReleaseRec), NULL},
     {"timestepMetadata", TimestepMetadataList,
      sizeof(struct _TimestepMetadataMsg), NULL},

--- a/fm/fm_formats.c
+++ b/fm/fm_formats.c
@@ -846,6 +846,7 @@ type_alignment(FMFormat fmformat, int field)
 	    case unknown_type: case string_type:
 		assert(0);
 	    case float_type:
+		if (size == -1) return -1;
 		if (size < sizeof(float)) return size;
 		if (size < sizeof(double)) return FMOffset(sf, f);
 		if (size < sizeof(long double)) return FMOffset(sd, d);
@@ -960,7 +961,7 @@ set_sizes_and_offsets(FMFormat top, int index, FMStructDescList structs)
 	    free(base_type);
 	}
 	align_req = type_alignment(f, i);
-    
+
 	if (align_req > 0) {
 	    if (align_req > f->alignment) {
 		f->alignment = align_req;


### PR DESCRIPTION
## Summary
- `type_alignment()` float case: `int size` compared against `size_t sizeof()` when size is -1, wrapping negative to huge positive and returning long double alignment (16) instead of unknown (-1). Adds the same `size == -1` guard the integer case has.
- `adios2_bug` test: used `sizeof(_TimestepMetadataDistributionMsg)` instead of `sizeof(_ReturnMetadataInfo)` for format registration, causing undersized decode buffers.