### PR TITLE
Use (void) in function prototypes for C23 compatibility, bump to 3.2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.14)
 # The directory label is used for CDash to treat FFS as a subproject of GTKorvo
 set(CMAKE_DIRECTORY_LABELS FFS)
 
-project(FFS VERSION 3.2.0)
+project(FFS VERSION 3.2.1)
 
 # Some boilerplate to setup nice output directories
 include(GNUInstallDirs)

--- a/cod/cod.h
+++ b/cod/cod.h
@@ -83,12 +83,16 @@ typedef struct _FMformat_list {
 
   This is used to associate textual names with addresses.
 */
-typedef struct extern_entry {
+struct extern_entry {
     /*! the textual name of the external entry */
     char *extern_name;
     /*! the address of the external entry */
     void *extern_value;
-} cod_extern_entry;
+};
+#ifndef COD_EXTERN_ENTRY_DEFINED
+typedef struct extern_entry cod_extern_entry;
+#define COD_EXTERN_ENTRY_DEFINED
+#endif
 
 /*!
  * A list of cod_extern_entry structures.  This is used to specify the

--- a/fm/fm.h
+++ b/fm/fm.h
@@ -9,8 +9,8 @@ extern "C" {
 
 typedef struct _FMContextStruct *FMContext;
 
-extern FMContext create_FMcontext();
-extern FMContext create_local_FMcontext();
+extern FMContext create_FMcontext(void);
+extern FMContext create_local_FMcontext(void);
 extern void set_ignore_default_values_FMcontext(FMContext c);
 extern void free_FMcontext(FMContext c);
 extern void ffs_free(void *ptr);


### PR DESCRIPTION
Change `create_FMcontext()` and `create_local_FMcontext()` prototypes in `fm.h` from empty parens to `(void)`. Also adjust definition of cod_extern_entry to mesh better with ADIOS.