### PR TITLE
CI test with dill 3.4.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-
+# Test CI with dill 3.4.1 JIT_PROTECT fix
 # The directory label is used for CDash to treat FFS as a subproject of GTKorvo
 set(CMAKE_DIRECTORY_LABELS FFS)
 


### PR DESCRIPTION
Test CI with dill 3.4.1 JIT_PROTECT fix in dill_finalize_package and dill_free_stream.