### PR TITLE
Bump version to 3.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.14)
 # The directory label is used for CDash to treat FFS as a subproject of GTKorvo
 set(CMAKE_DIRECTORY_LABELS FFS)
 
-project(FFS VERSION 3.2.1)
+project(FFS VERSION 3.3.0)
 
 # Some boilerplate to setup nice output directories
 include(GNUInstallDirs)


### PR DESCRIPTION
Prepares for v3.3.0 release.

Justified as a minor (not patch) bump given changes since v3.2.0:
- New feature: HTTP format server with CGI backend
- New dependency requirement: dill >= 3.3.0
- Behavior change: narrow conversion reset to only affect same-name formats